### PR TITLE
feat: add marketing landing page with auth-aware navigation

### DIFF
--- a/frontend/public/assets/coin-character.svg
+++ b/frontend/public/assets/coin-character.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+  <defs>
+    <radialGradient id="skin3" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#ffe0b2"/>
+      <stop offset="100%" stop-color="#ffb74d"/>
+    </radialGradient>
+    <linearGradient id="shirt2" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#aed581"/>
+      <stop offset="100%" stop-color="#689f38"/>
+    </linearGradient>
+    <linearGradient id="pants2" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#90caf9"/>
+      <stop offset="100%" stop-color="#1e88e5"/>
+    </linearGradient>
+  </defs>
+  <circle cx="60" cy="50" r="30" fill="url(#skin3)"/>
+  <rect x="40" y="80" width="40" height="80" rx="20" fill="url(#shirt2)"/>
+  <rect x="40" y="160" width="15" height="40" rx="8" fill="url(#pants2)"/>
+  <rect x="65" y="160" width="15" height="40" rx="8" fill="url(#pants2)"/>
+  <circle cx="150" cy="130" r="35" fill="#ffd54f" stroke="#fbc02d" stroke-width="6"/>
+  <text x="150" y="140" font-size="30" text-anchor="middle" fill="#f57f17">$</text>
+  <rect x="120" y="160" width="15" height="30" fill="#66bb6a"/>
+  <rect x="140" y="150" width="15" height="40" fill="#66bb6a"/>
+  <rect x="160" y="135" width="15" height="55" fill="#66bb6a"/>
+</svg>

--- a/frontend/public/assets/doodles.svg
+++ b/frontend/public/assets/doodles.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <g fill="none" stroke="#c7b8ff" stroke-width="2">
+    <circle cx="20" cy="20" r="8"/>
+    <rect x="60" y="10" width="20" height="20" rx="5"/>
+    <path d="M10 60 l15 15 l-15 15"/>
+    <path d="M80 80 l-10 -15 l10 -15"/>
+  </g>
+</svg>

--- a/frontend/public/assets/jump-character.svg
+++ b/frontend/public/assets/jump-character.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+  <defs>
+    <radialGradient id="skin2" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#ffe0b2"/>
+      <stop offset="100%" stop-color="#ffb74d"/>
+    </radialGradient>
+    <linearGradient id="jacket" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#ff8a65"/>
+      <stop offset="100%" stop-color="#d84315"/>
+    </linearGradient>
+    <linearGradient id="pants" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#90caf9"/>
+      <stop offset="100%" stop-color="#1e88e5"/>
+    </linearGradient>
+  </defs>
+  <circle cx="100" cy="40" r="30" fill="url(#skin2)"/>
+  <rect x="80" y="70" width="40" height="80" rx="20" fill="url(#jacket)"/>
+  <rect x="80" y="150" width="15" height="40" rx="8" fill="url(#pants)" transform="rotate(-20 80 150)"/>
+  <rect x="105" y="150" width="15" height="40" rx="8" fill="url(#pants)" transform="rotate(20 105 150)"/>
+  <polygon points="40,20 45,35 60,35 48,45 53,60 40,50 27,60 32,45 20,35 35,35" fill="#ffd54f"/>
+</svg>

--- a/frontend/public/assets/target-character.svg
+++ b/frontend/public/assets/target-character.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+  <defs>
+    <radialGradient id="skin" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#ffe0b2"/>
+      <stop offset="100%" stop-color="#ffb74d"/>
+    </radialGradient>
+    <linearGradient id="shirt" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#4fc3f7"/>
+      <stop offset="100%" stop-color="#0288d1"/>
+    </linearGradient>
+  </defs>
+  <circle cx="60" cy="50" r="30" fill="url(#skin)"/>
+  <rect x="40" y="80" width="40" height="80" rx="20" fill="url(#shirt)"/>
+  <circle cx="150" cy="120" r="40" fill="#fff"/>
+  <circle cx="150" cy="120" r="30" fill="#ff5252"/>
+  <circle cx="150" cy="120" r="20" fill="#fff"/>
+  <circle cx="150" cy="120" r="10" fill="#ff5252"/>
+  <line x1="140" y1="150" x2="175" y2="95" stroke="#424242" stroke-width="4"/>
+  <polygon points="175,95 165,100 170,90" fill="#424242"/>
+</svg>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,10 +1,11 @@
 import React, { useState, useEffect } from 'react';
-import { BrowserRouter as Router, Routes, Route, Navigate, Link } from 'react-router-dom';
+import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
 import Login from './components/Login';
 import Reviews from './components/Reviews';
 import Comic from './components/Comic';
 import MyComics from './components/MyComics';
 import NavBar from './components/NavBar';
+import LandingPage from './components/LandingPage';
 
 function App() {
   const [token, setToken] = useState(localStorage.getItem('token'));
@@ -37,16 +38,27 @@ function App() {
 
   return (
     <Router>
-      {token && <NavBar logout={logout} />}
+      <NavBar token={token} logout={logout} />
       <div className="container">
-        <div style={{ padding: '20px' }}>
-          <Routes>
-            <Route path="/" element={token ? <Navigate to="/reviews" /> : <Login onLogin={handleLogin} />} />
-            <Route path="/reviews" element={token ? <Reviews token={token} /> : <Navigate to="/" />} />
-            <Route path="/comic" element={token ? <Comic token={token} /> : <Navigate to="/" />} />
-            <Route path="/my-comics" element={token ? <MyComics token={token} /> : <Navigate to="/" />} />
-          </Routes>
-        </div>
+        <Routes>
+          <Route path="/" element={<LandingPage token={token} />} />
+          <Route
+            path="/login"
+            element={token ? <Navigate to="/reviews" /> : <Login onLogin={handleLogin} />}
+          />
+          <Route
+            path="/reviews"
+            element={token ? <Reviews token={token} /> : <Navigate to="/login" />}
+          />
+          <Route
+            path="/comic"
+            element={token ? <Comic token={token} /> : <Navigate to="/login" />}
+          />
+          <Route
+            path="/my-comics"
+            element={token ? <MyComics token={token} /> : <Navigate to="/login" />}
+          />
+        </Routes>
       </div>
     </Router>
   );

--- a/frontend/src/components/LandingPage.css
+++ b/frontend/src/components/LandingPage.css
@@ -1,0 +1,66 @@
+.landing-page {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  min-height: calc(100vh - 60px);
+  background-color: #e5d1ff;
+  background-image: url('/assets/doodles.svg');
+  background-repeat: repeat;
+  padding: 40px 20px;
+  box-sizing: border-box;
+}
+
+.hero-text {
+  max-width: 500px;
+  color: #341f97;
+}
+
+.hero-text h1 {
+  font-size: 2.5rem;
+  margin-bottom: 1rem;
+}
+
+.hero-text p {
+  font-size: 1.1rem;
+  margin-bottom: 1.5rem;
+}
+
+.hero-text button {
+  background-color: #8b5cf6;
+  color: #fff;
+  padding: 12px 24px;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+.hero-art {
+  position: relative;
+  flex: 1;
+  min-width: 300px;
+  height: 400px;
+}
+
+.hero-art img {
+  position: absolute;
+}
+
+.hero-target {
+  left: 0;
+  bottom: 0;
+  width: 200px;
+}
+
+.hero-jump {
+  right: 80px;
+  top: -20px;
+  width: 180px;
+}
+
+.hero-coin {
+  right: 0;
+  bottom: 0;
+  width: 200px;
+}

--- a/frontend/src/components/LandingPage.js
+++ b/frontend/src/components/LandingPage.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import './LandingPage.css';
+
+export default function LandingPage({ token }) {
+  const navigate = useNavigate();
+  const go = () => {
+    if (token) navigate('/reviews');
+    else navigate('/login');
+  };
+
+  return (
+    <div className="landing-page">
+      <div className="hero-text">
+        <h1>Grow Your Business with Effective Marketing</h1>
+        <p>Reach your target audience and drive sales with our innovative marketing solutions.</p>
+        <button onClick={go}>Get Started</button>
+      </div>
+      <div className="hero-art">
+        <img src="/assets/target-character.svg" alt="target" className="hero-target" />
+        <img src="/assets/jump-character.svg" alt="jump" className="hero-jump" />
+        <img src="/assets/coin-character.svg" alt="coin" className="hero-coin" />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/Login.js
+++ b/frontend/src/components/Login.js
@@ -1,16 +1,22 @@
 import React, { useState } from 'react';
 import axios from 'axios';
+import { useNavigate } from 'react-router-dom';
 
 export default function Login({ onLogin }) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [isRegister, setIsRegister] = useState(false);
+  const navigate = useNavigate();
 
   const submit = async () => {
     const url = isRegister ? '/register' : '/login';
     const res = await axios.post(url, { email, password });
-    if (!isRegister) onLogin(res.data.access_token);
-    else setIsRegister(false);
+    if (!isRegister) {
+      onLogin(res.data.access_token);
+      navigate('/reviews');
+    } else {
+      setIsRegister(false);
+    }
   };
 
   return (

--- a/frontend/src/components/NavBar.js
+++ b/frontend/src/components/NavBar.js
@@ -1,14 +1,20 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 
-export default function NavBar({ logout }) {
+export default function NavBar({ token, logout }) {
   return (
     <header className="navbar">
-      <div className="logo">Enchanta</div>
+      <div className="logo"><Link to="/">Enchanta</Link></div>
       <div className="nav-links">
-        <Link to="/reviews"><span className="icon">🏠</span>Home</Link>
-        <Link to="/my-comics"><span className="icon">📚</span>My Comics</Link>
-        <button onClick={logout}><span className="icon">🚪</span>Logout</button>
+        {token ? (
+          <>
+            <Link to="/reviews"><span className="icon">🏠</span>Home</Link>
+            <Link to="/my-comics"><span className="icon">📚</span>My Comics</Link>
+            <button onClick={logout}><span className="icon">🚪</span>Logout</button>
+          </>
+        ) : (
+          <Link to="/login"><span className="icon">🔐</span>Sign In</Link>
+        )}
       </div>
     </header>
   );

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,13 +1,13 @@
 body {
   margin: 0;
   font-family: 'Arial', sans-serif;
-  background: #000;
-  color: #eee;
+  background: #f3e8ff;
+  color: #1f2937;
 }
 
 button {
-  background-color: #bb86fc;
-  color: #000;
+  background-color: #8b5cf6;
+  color: #fff;
   padding: 10px 20px;
   border: none;
   margin: 5px;
@@ -29,7 +29,7 @@ input, select {
 }
 
 .navbar {
-  background-color: #6200ea;
+  background-color: #8b5cf6;
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -41,6 +41,11 @@ input, select {
 .logo {
   font-weight: bold;
   font-size: 1.2rem;
+}
+
+.logo a {
+  color: inherit;
+  text-decoration: none;
 }
 
 .nav-links {
@@ -70,15 +75,15 @@ input, select {
 }
 
 .auth-container {
-  background-color: rgba(255, 255, 255, 0.4);
+  background-color: rgba(255, 255, 255, 0.8);
   padding: 20px;
   border-radius: 8px;
-  box-shadow: 0 2px 4px rgba(255, 255, 255, 0.1);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   max-width: 400px;
   margin: 40px auto;
   display: flex;
   flex-direction: column;
-  color: black;
+  color: #1f2937;
 }
 
 .reviews-list {
@@ -90,12 +95,12 @@ input, select {
   margin: 8px 0;
   padding: 10px;
   border-radius: 5px;
-  background: #1e1e1e;
-  box-shadow: 0 1px 2px rgba(255, 255, 255, 0.1);
+  background: #fff;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
 }
 
 .reviews-list li.selected {
-  background: #333;
+  background: #e9d5ff;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
 }
 
@@ -105,11 +110,12 @@ input, select {
   gap: 15px;
 }
 
+
 .comic-card {
-  background: #1e1e1e;
+  background: #fff;
   padding: 10px;
   border-radius: 8px;
-  box-shadow: 0 2px 4px rgba(255, 255, 255, 0.1);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   position: relative;
   transition: transform 0.2s, box-shadow 0.2s;
   cursor: pointer;
@@ -117,7 +123,7 @@ input, select {
 
 .comic-card:hover {
   transform: translateY(-4px);
-  box-shadow: 0 4px 12px rgba(255, 255, 255, 0.2);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
 }
 
 .download-btn {
@@ -136,13 +142,14 @@ input, select {
   cursor: pointer;
 }
 
+
 .modal {
   position: fixed;
   top: 0;
   left: 0;
   width: 100%;
   height: 100%;
-  background: rgba(0, 0, 0, 0.9);
+  background: rgba(0, 0, 0, 0.8);
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## Summary
- Introduce marketing-style landing page with doodle background and 3D cartoon assets
- Update navbar and routing to handle unauthenticated sign-in and authenticated home/my comics/logout
- Apply purple color palette and redirect login to reviews page

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm install` *(fails: 403 Forbidden fetching tsutils)*

------
https://chatgpt.com/codex/tasks/task_e_68ba1423f668833188b97e31aaae9786