### PR TITLE
feat: redesign landing page and improve auth flow

### DIFF
--- a/frontend/src/components/LandingPage.css
+++ b/frontend/src/components/LandingPage.css
@@ -1,51 +1,85 @@
-/* Wrapper */
+/* Landing page layout */
 .landing-page {
   display: flex;
-  margin-left: -100px;
-  margin-top: 50px;  
-  padding: 2rem 5vw;
-  box-sizing: border-box;
+  flex-direction: column;
+  align-items: center;
+  padding: 4rem 1rem;
+  text-align: center;
 }
 
-/* Text */
-.hero-text {
-  max-width: 600px;
-  color: #fff;
-  z-index: 2;
+/* Hero section */
+.hero {
+  max-width: 900px;
 }
 
-.hero-text h1 {
-  font-size: clamp(2rem, 2vw, 3rem);
+.hero h1 {
+  font-size: clamp(2rem, 5vw, 3.5rem);
+  font-weight: 700;
+  line-height: 1.2;
   margin-bottom: 1rem;
-  font-weight: bold;
-  line-height: 1.1;
 }
 
-.hero-text p {
-  font-size: clamp(1rem, 0.5vw, 1.3rem);
-  margin-bottom: 1.5rem;
+.hero p {
+  font-size: clamp(1rem, 2.5vw, 1.25rem);
+  margin-bottom: 2rem;
   line-height: 1.4;
 }
 
-.hero-text button {
-  background-color: #FE4E8F;
+.cta-buttons {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+}
+
+.start-btn {
+  background-color: #2674f1;
   color: #fff;
-  padding: 12px 24px;
   border: none;
-  border-radius: 8px;
-  cursor: pointer;
+  padding: 0.75rem 1.5rem;
+  border-radius: 9999px;
   font-size: 1rem;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.5);
+  cursor: pointer;
 }
 
-.hero-text button:hover {
-  background-color: transparent;
+.examples-btn {
+  background-color: #fff;
+  border: 2px solid #222;
+  padding: 0.75rem 1.5rem;
+  border-radius: 9999px;
+  font-size: 1rem;
+  cursor: pointer;
 }
 
-/* Mobile Responsive */
+/* Feature section */
+.features {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 2rem;
+  margin-top: 4rem;
+  max-width: 1000px;
+}
+
+.feature {
+  max-width: 260px;
+}
+
+.feature h3 {
+  margin-bottom: 0.5rem;
+  font-size: 1.25rem;
+}
+
+.feature p {
+  font-size: 1rem;
+  line-height: 1.4;
+}
+
 @media (max-width: 768px) {
-  .landing-page {
-    justify-content: center; /* ✅ center on mobile */
-    text-align: center;
+  .cta-buttons {
+    flex-direction: column;
+  }
+  .features {
+    flex-direction: column;
+    align-items: center;
   }
 }

--- a/frontend/src/components/LandingPage.js
+++ b/frontend/src/components/LandingPage.js
@@ -11,16 +11,31 @@ export default function LandingPage({ token }) {
 
   return (
     <div className="landing-page">
-      <div className="hero-text">
-        <h1>
-          Grow Your Business with <br /> Effective Marketing
-        </h1>
+      <section className="hero">
+        <h1>Turn customer reviews & sales data into scroll-stopping visuals</h1>
         <p>
-          Reach your target audience and drive sales <br/> with our innovative marketing
-          solutions.
+          Havasa transforms text and numbers into on-brand content, carousels, and
+          stories that boost clicks, saves, and shares.
         </p>
-        <button onClick={go}>Get Started</button>
-      </div>
+        <div className="cta-buttons">
+          <button className="start-btn" onClick={go}>Start Free</button>
+          <button className="examples-btn">See Examples</button>
+        </div>
+      </section>
+      <section className="features">
+        <div className="feature">
+          <h3>Connect</h3>
+          <p>Plug in your reviews & sales sources (Google, Yelp, Shopify).</p>
+        </div>
+        <div className="feature">
+          <h3>Generate</h3>
+          <p>Pick a vibe; Havasa creates mini cartoons, carousels, and scripts.</p>
+        </div>
+        <div className="feature">
+          <h3>Publish</h3>
+          <p>One-click export to Instagram, Reels, and web.</p>
+        </div>
+      </section>
     </div>
   );
 }

--- a/frontend/src/components/Login.js
+++ b/frontend/src/components/Login.js
@@ -28,6 +28,7 @@ export default function Login({ onLogin }) {
       <button onClick={() => setIsRegister(!isRegister)}>
         {isRegister ? 'Have an account? Login' : 'No account? Register'}
       </button>
+      <button onClick={() => navigate('/')}>Back to Home</button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- refresh landing page with marketing-focused hero copy and feature sections
- add responsive styles for new layout
- allow navigation back to landing page from login/registration screen

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/tsutils)*
- `npm test --silent` *(fails: sh: 1: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bce65fd32083318c39ed440870ddd3