### PR TITLE
Use charcoal palette for interactive elements

### DIFF
--- a/frontend/src/components/LandingPage.css
+++ b/frontend/src/components/LandingPage.css
@@ -32,7 +32,7 @@
 }
 
 .start-btn {
-  background-color: #2674f1;
+  background-color: #36454F;
   color: #fff;
   border: none;
   padding: 0.75rem 1.5rem;
@@ -43,7 +43,8 @@
 
 .examples-btn {
   background-color: #fff;
-  border: 2px solid #222;
+  border: 2px solid #36454F;
+  color: #36454F;
   padding: 0.75rem 1.5rem;
   border-radius: 9999px;
   font-size: 1rem;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -14,8 +14,12 @@ body {
   margin: 0;
 }
 
+a {
+  color: #36454F;
+}
+
 button {
-  background-color: #FE4E8F;
+  background-color: #36454F;
   color: #fff;
   padding: 10px 20px;
   border: none;
@@ -42,7 +46,7 @@ input, select {
 }
 
 .navbar {
-  background-color: #2674f1; /* match new palette */
+  background-color: #36454F;
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -71,9 +75,9 @@ input, select {
 .nav-links a,
 .nav-links button {
   background-color: #fff;
-  color: #2674f1;
+  color: #36454F;
   padding: 12px 24px;
-  border: 2px solid #fff;
+  border: 2px solid #36454F;
   border-radius: 8px;
   cursor: pointer;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);


### PR DESCRIPTION
## Summary
- Replace blue accents with charcoal across buttons and navigation links for a unified palette
- Set global anchor styling to charcoal to keep links consistent

## Testing
- `npm install` *(fails: 403 Forbidden - tsutils)*
- `CI=true npm test` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd268e419483319e12276434d29d84