### PR TITLE
feat: add landing page feature cards

### DIFF
--- a/frontend/src/components/LandingPage.css
+++ b/frontend/src/components/LandingPage.css
@@ -61,16 +61,26 @@
   max-width: 1000px;
 }
 
-.feature {
+.feature-card {
+  background-color: #fff8e6;
+  padding: 1.5rem;
+  border-radius: 1rem;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
   max-width: 260px;
+  text-align: left;
 }
 
-.feature h3 {
+.feature-icon {
+  font-size: 2rem;
+  margin-bottom: 1rem;
+}
+
+.feature-card h3 {
   margin-bottom: 0.5rem;
   font-size: 1.25rem;
 }
 
-.feature p {
+.feature-card p {
   font-size: 1rem;
   line-height: 1.4;
 }

--- a/frontend/src/components/LandingPage.js
+++ b/frontend/src/components/LandingPage.js
@@ -23,15 +23,24 @@ export default function LandingPage({ token }) {
         </div>
       </section>
       <section className="features">
-        <div className="feature">
+        <div className="feature-card">
+          <div className="feature-icon" role="img" aria-label="Connect">
+            🔗
+          </div>
           <h3>Connect</h3>
           <p>Plug in your reviews & sales sources (Google, Yelp, Shopify).</p>
         </div>
-        <div className="feature">
+        <div className="feature-card">
+          <div className="feature-icon" role="img" aria-label="Generate">
+            ✨
+          </div>
           <h3>Generate</h3>
           <p>Pick a vibe; Havasa creates mini cartoons, carousels, and scripts.</p>
         </div>
-        <div className="feature">
+        <div className="feature-card">
+          <div className="feature-icon" role="img" aria-label="Publish">
+            🚀
+          </div>
           <h3>Publish</h3>
           <p>One-click export to Instagram, Reels, and web.</p>
         </div>


### PR DESCRIPTION
## Summary
- style landing page with cream feature cards and icons

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm install` *(fails: 403 Forbidden when fetching tsutils)*

------
https://chatgpt.com/codex/tasks/task_e_68bd3195abdc83319acb820baae2ba17