### PR TITLE
Include merchant name in comic generation

### DIFF
--- a/backend/app/routers/comic.py
+++ b/backend/app/routers/comic.py
@@ -23,7 +23,8 @@ async def conversation(data: ConversationRequest, user: dict = Depends(get_curre
     if not openai.api_key:
         raise HTTPException(status_code=500, detail="OpenAI API key not configured")
     prompt = (
-        "These are 2 reviews from 2 different people. Mix both reviews and convert this into a cute conversation with proper start and ending. Make the content more fun."
+        f"These are 2 reviews from 2 different people about {data.merchant}. "
+        "Mix both reviews and convert this into a cute conversation with proper start and ending. Make the content more fun."
         + "\n".join(data.reviews)
     )
     resp = openai.chat.completions.create(
@@ -42,11 +43,12 @@ async def comic(data: ComicRequest, user: dict = Depends(get_current_user)):
         raise HTTPException(status_code=500, detail="OpenAI API key not configured")
 
     prompt = (
-        f"Create a high-quality, 3D cartoon comic strip of this conversation. "
+        f"Create a high-quality, 3D cartoon comic strip for the merchant {data.merchant}. "
         f"Make it visually engaging with appropriate backgrounds and foregrounds. "
         f"Focus on expressive characters, natural poses"
         f"Keep text minimal (speech bubbles only) and legible. "
         f"Create a complete image without stripping any side and maintaining consistency in characters. "
+        f"Ensure the merchant name '{data.merchant}' appears clearly in the comic. "
         f"Conversation: {data.conversation}"
     )
 
@@ -66,6 +68,7 @@ async def comic(data: ComicRequest, user: dict = Depends(get_current_user)):
         "user_id": user.get("sub"),
         "image": img_data,
         "prompt": prompt,
+        "merchant": data.merchant,
         "created_at": datetime.utcnow(),
     })
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -10,10 +10,12 @@ class Review(BaseModel):
 
 class ConversationRequest(BaseModel):
     reviews: List[str]
+    merchant: str
 
 
 class ComicRequest(BaseModel):
     conversation: str
+    merchant: str
 
 
 class ComicOut(BaseModel):

--- a/frontend/src/components/Comic.js
+++ b/frontend/src/components/Comic.js
@@ -5,14 +5,15 @@ export default function Comic({ token }) {
   const [conversation, setConversation] = useState('');
   const [image, setImage] = useState(null);
   const reviews = JSON.parse(localStorage.getItem('selectedReviews') || '[]');
+  const merchant = localStorage.getItem('merchant') || '';
 
   useEffect(() => {
     const generate = async () => {
-      const conv = await axios.post('/ai/conversation', { reviews }, {
+      const conv = await axios.post('/ai/conversation', { reviews, merchant }, {
         headers: { Authorization: `Bearer ${token}` },
       });
       setConversation(conv.data.conversation);
-      const img = await axios.post('/ai/comic', { conversation: conv.data.conversation }, {
+      const img = await axios.post('/ai/comic', { conversation: conv.data.conversation, merchant }, {
         headers: { Authorization: `Bearer ${token}` },
       });
       const imgData = img.data.image || img.data.image_url;

--- a/frontend/src/components/Reviews.js
+++ b/frontend/src/components/Reviews.js
@@ -26,6 +26,7 @@ export default function Reviews({ token }) {
 
   const goNext = () => {
     localStorage.setItem('selectedReviews', JSON.stringify(selected.slice(0, 3)));
+    localStorage.setItem('merchant', merchant);
     navigate('/comic');
   };
 


### PR DESCRIPTION
## Summary
- Pass merchant name through conversation and comic creation APIs so prompts and stored comics include the merchant.
- Persist selected merchant in frontend and send it along when generating conversations and comics.

## Testing
- `pytest`
- `npm install` *(fails: 403 Forbidden for tsutils)*
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf0c1a8f483318f82bf26f34c703c