### PR TITLE
Style refresh for auth, home, and comic gallery pages

### DIFF
--- a/frontend/src/components/LandingPage.css
+++ b/frontend/src/components/LandingPage.css
@@ -95,3 +95,23 @@
     align-items: center;
   }
 }
+
+/* Extra fun section */
+.fun-section {
+  margin-top: 3rem;
+  background: rgba(255, 255, 255, 0.4);
+  padding: 1.5rem;
+  border-radius: 1rem;
+  max-width: 800px;
+}
+
+.fun-section ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.fun-section li {
+  margin: 0.5rem 0;
+  font-size: 1.1rem;
+}

--- a/frontend/src/components/LandingPage.js
+++ b/frontend/src/components/LandingPage.js
@@ -45,6 +45,14 @@ export default function LandingPage({ token }) {
           <p>One-click export to Instagram, Reels, and web.</p>
         </div>
       </section>
+      <section className="fun-section">
+        <h2>Why you'll love Havasa</h2>
+        <ul>
+          <li>🎉 Turn boring data into colorful comics</li>
+          <li>🤖 Let AI craft stories for you</li>
+          <li>🌈 Share laughs with friends and fans</li>
+        </ul>
+      </section>
     </div>
   );
 }

--- a/frontend/src/components/Login.js
+++ b/frontend/src/components/Login.js
@@ -20,15 +20,23 @@ export default function Login({ onLogin }) {
   };
 
   return (
-    <div className="auth-container">
-      <h2>{isRegister ? 'REGISTER' : 'LOGIN'}</h2>
-      <input placeholder="Email" value={email} onChange={e => setEmail(e.target.value)} />
-      <input placeholder="Password" type="password" value={password} onChange={e => setPassword(e.target.value)} />
-      <button onClick={submit}>{isRegister ? 'Register' : 'Login'}</button>
-      <button onClick={() => setIsRegister(!isRegister)}>
-        {isRegister ? 'Have an account? Login' : 'No account? Register'}
-      </button>
-      <button onClick={() => navigate('/')}>Back to Home</button>
+    <div className="auth-page">
+      <div className="auth-container">
+        <h2>{isRegister ? 'REGISTER' : 'LOGIN'}</h2>
+        <p className="auth-tagline">Welcome to Havasa – where reviews become comics! 🎉</p>
+        <input placeholder="Email" value={email} onChange={e => setEmail(e.target.value)} />
+        <input
+          placeholder="Password"
+          type="password"
+          value={password}
+          onChange={e => setPassword(e.target.value)}
+        />
+        <button onClick={submit}>{isRegister ? 'Register' : 'Login'}</button>
+        <button onClick={() => setIsRegister(!isRegister)}>
+          {isRegister ? 'Have an account? Login' : 'No account? Register'}
+        </button>
+        <button onClick={() => navigate('/')}>Back to Home</button>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/MyComics.js
+++ b/frontend/src/components/MyComics.js
@@ -22,9 +22,16 @@ export default function MyComics({ token }) {
     };
     fetchComics();
   }, [token]);
-
-  if (loading) return <div>Fetching your Comics...</div>;
-  if (comics.length === 0) return <div>No comics generated yet.</div>;
+  if (loading) return <div className="loading-message">✨ Fetching your Comics...</div>;
+  if (comics.length === 0)
+    return (
+      <div className="my-comics-page">
+        <h2>🎨 My Comics</h2>
+        <p className="my-comics-tagline">
+          No comics generated yet. Start creating to fill this space! 🚀
+        </p>
+      </div>
+    );
 
   const handleDownload = (src, i) => {
     const link = document.createElement('a');
@@ -34,8 +41,9 @@ export default function MyComics({ token }) {
   };
 
   return (
-    <div>
-      <h2>My Comics</h2>
+    <div className="my-comics-page">
+      <h2>🎨 My Comics</h2>
+      <p className="my-comics-tagline">Click a comic to view and download it! 🎉</p>
       <div className="comic-grid">
         {comics.map((c, i) => {
           const src = c.image.startsWith('http') ? c.image : `data:image/png;base64,${c.image}`;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -99,7 +99,21 @@ input, select {
   margin: 40px auto;
   display: flex;
   flex-direction: column;
+  align-items: center;
   color: #1f2937;
+}
+
+.auth-page {
+  min-height: 80vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+}
+
+.auth-tagline {
+  margin-bottom: 1rem;
+  color: #fff;
 }
 
 .reviews-list {
@@ -179,6 +193,19 @@ input, select {
   background: rgba(255, 255, 255, 0.9);
   padding: 10px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.my-comics-page {
+  text-align: center;
+}
+
+.my-comics-tagline {
+  margin-bottom: 1rem;
+}
+
+.loading-message {
+  text-align: center;
+  margin-top: 40px;
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- Centered login/register form with a playful tagline
- Expanded landing page with a fun feature section
- Added friendly messaging and instructions to the MyComics gallery

## Testing
- `CI=true npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bdff40f748833191bd33e4fcc96119