### PR TITLE
Add animated review placeholder and comic generation spinner

### DIFF
--- a/frontend/src/components/Reviews.js
+++ b/frontend/src/components/Reviews.js
@@ -9,7 +9,8 @@ export default function Reviews({ token }) {
   const [place, setPlace] = useState('');
   const [reviews, setReviews] = useState([]);
   const [selected, setSelected] = useState([]);
-  const [showComic, setShowComic] = useState(false);  
+  const [showComic, setShowComic] = useState(false);
+  const [generating, setGenerating] = useState(false);
   const navigate = useNavigate();
 
   const fetchReviews = async () => {
@@ -30,10 +31,14 @@ export default function Reviews({ token }) {
   // If you still want to navigate to /comic, keep goNext().
   // If you want to render the comic on the right in place of reviews,
   // set showComic = true and render there.
-  const goNext = () => {
+  const goNext = async () => {
     localStorage.setItem('selectedReviews', JSON.stringify(selected.slice(0, 3)));
     localStorage.setItem('merchant', merchant);
-    // navigate('/comic'); // <- old behavior
+    setGenerating(true);
+    setShowComic(false);
+    // simulate async comic generation
+    await new Promise((res) => setTimeout(res, 2000));
+    setGenerating(false);
     setShowComic(true);     // <- show comic on the right instead
   };
 
@@ -72,9 +77,22 @@ export default function Reviews({ token }) {
         <button className="btn-primary" onClick={fetchReviews}>Search</button>
       </aside>
 
-      {/* RIGHT: Reviews list OR Comic */}
+      {/* RIGHT: placeholder, reviews list, generating animation or Comic */}
       <section className="right-pane">
-        {!showComic ? (
+        {generating ? (
+          <div className="generating-animation">
+            <div className="spinner" />
+            <p>Generating comic...</p>
+          </div>
+        ) : showComic ? (
+          <div className="comic-wrap">
+            <h3 className="pane-title">Generated Comic</h3>
+            {/* Replace with your real comic image or component */}
+            <div className="comic-placeholder">
+              Your comic appears here (replace with actual image/component).
+            </div>
+          </div>
+        ) : reviews.length > 0 ? (
           <>
             <h3 className="pane-title">Select Reviews</h3>
             <ul className="reviews-list">
@@ -98,12 +116,8 @@ export default function Reviews({ token }) {
             </div>
           </>
         ) : (
-          <div className="comic-wrap">
-            <h3 className="pane-title">Generated Comic</h3>
-            {/* Replace with your real comic image or component */}
-            <div className="comic-placeholder">
-              Your comic appears here (replace with actual image/component).
-            </div>
+          <div className="placeholder">
+            <div className="placeholder-animation">Your reviews will appear here</div>
           </div>
         )}
       </section>

--- a/frontend/src/css/reviews.css
+++ b/frontend/src/css/reviews.css
@@ -135,6 +135,53 @@
   color: #6D7680;
 }
 
+/* ----- Placeholder & generating animations ----- */
+.placeholder,
+.generating-animation {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  text-align: center;
+}
+
+.placeholder-animation {
+  font-size: 18px;
+  color: #6D7680;
+  animation: pulse 1.8s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%, 100% {
+    opacity: 0.4;
+    transform: scale(0.98);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.spinner {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  border: 5px solid #2BC4A4;
+  border-top-color: transparent;
+  animation: spin 1s linear infinite;
+  margin-bottom: 12px;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.generating-animation p {
+  margin: 0;
+  color: #2A2D34;
+}
+
 /* ----- Small screens: stack vertically ----- */
 @media (max-width: 980px) {
   .reviews-page {


### PR DESCRIPTION
## Summary
- show an animated placeholder on the review page before reviews are loaded
- indicate comic generation with a spinner before rendering the comic

## Testing
- `npm test --prefix frontend -- --watchAll=false` *(fails: sh: 1: react-scripts: not found)*
- `npm install --prefix frontend` *(fails: 403 Forbidden - GET https://registry.npmjs.org/tsutils)*

------
https://chatgpt.com/codex/tasks/task_e_68be0ae6fed08331bd4470285a042841